### PR TITLE
Automatically start monitor after upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,11 @@
           "type": ["string", "null"],
           "default": null,
           "description": "Custom PATH for `platformio` command. Paste here the result of `echo $PATH` (Unix) / `echo %PATH%` (Windows) command by typing into your system terminal if you prefer to use custom version of PlatformIO Core"
+        },
+        "platformio-ide.uploadAndMonitor": {
+          "type": "boolean",
+          "default": true,
+          "description": "Use Upload and Monitor task instead of just uploading the file."
         }
       }
     }

--- a/src/terminal.js
+++ b/src/terminal.js
@@ -16,7 +16,6 @@ export default class PIOTerminal {
 
   constructor() {
     this._instance = null;
-    this._lastCommand = null;
   }
 
   new() {
@@ -53,12 +52,10 @@ export default class PIOTerminal {
 
     this._instance = vscode.window.createTerminal('PlatformIO', constants.IS_WINDOWS ? 'cmd.exe' : null);
     commands.forEach(cmd => this._instance.sendText(cmd));
-    this._lastCommand = null;
     return this._instance;
   }
 
   sendText(text) {
-    this._lastCommand = text;
     if (!this._instance) {
       this.new();
     }
@@ -66,17 +63,10 @@ export default class PIOTerminal {
     this._instance.show();
   }
 
-  closeSerialMonitor() {
-    if (this._lastCommand && this._lastCommand.includes('device monitor')) {
-      this.dispose();
-    }
-  }
-
   dispose() {
     if (this._instance) {
       this._instance.dispose();
     }
-    this._lastCommand = null;
     this._instance = null;
   }
 }


### PR DESCRIPTION
This makes the upload action immediately start serial monitor. This solves the problem with serial monitor preventing the upload action from working, and vice-versa. I was unable to figure out a better solution, given that vscode has no APIs to detect task completition, so the method used in Atom is not possible here :/