### PR TITLE
Fix problem matcher file location

### DIFF
--- a/package.json
+++ b/package.json
@@ -507,10 +507,7 @@
       {
         "name": "platformio",
         "owner": "cpp",
-        "fileLocation": [
-          "relative",
-          "${workspaceFolder}"
-        ],
+	"fileLocation": "autoDetect",
         "pattern": {
           "regexp": "^([^:\\n]+):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
           "file": 1,


### PR DESCRIPTION
Platformio output contains absolute file names. This fixes a bug where a detected error/warning cannot be opened in the editor, since the matched file path is then erroneously appended to the workspace path.