### PR TITLE
Added host IP setting option to enable plugin use for dockerized code-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -598,6 +598,11 @@
           "type": "integer",
           "description": "PIO Home server HTTP port (the default value 0 automatically assigns a free port in the range [8010..8100])"
         },
+        "platformio-ide.pioHomeServerHttpHost": {
+          "type": "string",
+          "default": "127.0.0.1",
+          "description": "PIO Home server HTTP host (default is 127.0.0.1, but in case of dockerized environments 0.0.0.0)"
+        },
         "platformio-ide.customPyPiIndexUrl": {
           "type": [
             "string",

--- a/src/home.js
+++ b/src/home.js
@@ -95,6 +95,7 @@ export default class PIOHome {
     this._lastStartUrl = startUrl;
     await pioNodeHelpers.home.ensureServerStarted({
       port: extension.getSetting('pioHomeServerHttpPort'),
+      host: extension.getSetting('pioHomeServerHttpHost'),
       onIDECommand: async (command, params) => {
         if (command === 'open_project') {
           if (extension.projectObservable) {


### PR DESCRIPTION
Adding the host IP argument is also required in the platformio-node-helpers. See my other pull request there.