### PR TITLE
Respect "extensions.autoupdate" setting

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -57,7 +57,10 @@ class PlatformIOVSCodeExtension {
     }
 
     this.patchOSEnviron();
-    await this.startInstaller(!hasPIOProject);
+    const UpdateCheckEnabled = vscode.workspace
+        .getConfiguration('extensions')
+        .get('autoUpdate');
+    await this.startInstaller(!UpdateCheckEnabled);
     this.subscriptions.push(this.handleUseDevelopmentPIOCoreConfiguration());
 
     vscode.commands.executeCommand('setContext', 'pioCoreReady', true);


### PR DESCRIPTION
If "extensions.autoupdate" setting is set to false, do not start pio installer to check for updates.

This mitigates the still present bug in the installer which deletes (part?) of pio-core _before_ safely downloading the update.
So if "extensions.autoupdate" is false, issues https://github.com/platformio/platformio-vscode-ide/issues/2398 and https://github.com/platformio/platformio-vscode-ide/issues/2406 do not occur.

