### PR TITLE
Fix select all, undo, and redo on macOS

### DIFF
--- a/src/home.js
+++ b/src/home.js
@@ -127,11 +127,23 @@ export default class PIOHome {
     const iframeId = `pioHomeIFrame-${vscode.env.sessionId}`;
     const iframeScript = `
 <script>
-  for (const command of ['selectAll', 'copy', 'paste', 'cut', 'undo', 'redo']) {
+  function execCommand(data) {
+    document.getElementById('${iframeId}').contentWindow.postMessage({'command': 'execCommand', 'data': data}, '*');
+  }
+  for (const command of ['copy', 'paste', 'cut']) {
     document.addEventListener(command, (e) => {
-      document.getElementById('${iframeId}').contentWindow.postMessage({'command': 'execCommand', 'data': command}, '*');
+      execCommand(command);
     });
   }
+  document.addEventListener('selectstart', (e) => {
+    execCommand('selectAll');
+    e.preventDefault();
+  });
+  window.addEventListener('keydown', (e) => {
+    if (e.key === 'z' && e.metaKey) {
+      execCommand(e.shiftKey ? 'redo' : 'undo');
+    }
+  });
   window.addEventListener('message', (e) => {
     if (e.data.command === 'kbd-event') {
       window.dispatchEvent(new KeyboardEvent('keydown', e.data.data));


### PR DESCRIPTION
`selectAll`, `undo`, and `redo` are not supported events in `document.addEventListener` (https://developer.mozilla.org/en-US/docs/Web/Events).

To handle select all, we can detect a `selectStart` event, which only fires if something outside the iframe is selected. This is only achievable if select all is used as the iframe takes up the entire window. If so, then we execute the command and prevent the incorrect selection from occurring.

Undo/redo events do not exist (https://stackoverflow.com/a/15516286), so we can instead manually listen for Cmd+Z/Cmd+Shift+Z. Unfortunately, this doesn't work with the Edit->Undo/Redo from the menu bar, but it's better than nothing.

This fixes #3364 and also fixes #3119.

(Loving PlatformIO, thanks for all the work put into it!)