### PR TITLE
Fix upload and monitor is already active.

### DIFF
--- a/src/project/tasks.js
+++ b/src/project/tasks.js
@@ -230,7 +230,7 @@ export default class ProjectTaskManager {
     const args1 = this.getTaskArgs(task1);
     const args2 = this.getTaskArgs(task2);
     return (
-      args1.length === args2.length &&
+      ((args1.length === args2.length) || (args2.length - args1.length === 4)) &&
       args1.every((value, index) => value === args2[index])
     );
   }


### PR DESCRIPTION
Fix "the task 'platformio: upload and monitor (Project Name)' is already active." Fix areTasksEqual return false when running upload and monitor task the running task has args like ['--upload-port', 'COM0', '--monitor-port', 'COM0'] added.