### PR TITLE
Added the option to use custom paths for the platforms, packages, cache and projects directories and added the option to turn on/off telemetry

### DIFF
--- a/package.json
+++ b/package.json
@@ -750,6 +750,38 @@
           "default": null,
           "description": "Custom PATH for the `platformio` command, if you prefer to use a custom version of PlatformIO Core. Fill in the result of the system terminal command `echo $PATH` (Unix) / `echo %PATH%` (Windows)."
         },
+        "platformio-ide.platformsPATH": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "description": "Custom PATH for the platforms directory, it will be the value of the enviroment variable PLATFORMIO_PLATFORMS_DIR."
+        },
+        "platformio-ide.packagesPATH": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "description": "Custom PATH for the packages directory, it will be the value of the enviroment variable PLATFORMIO_PACKAGES_DIR."
+        },
+        "platformio-ide.cachePATH": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "description": "Custom PATH for the cache directory, it will be the value of the enviroment variable PLATFORMIO_CACHE_DIR."
+        },
+        "platformio-ide.projectsDirectoryPATH": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "description": "Custom PATH for the projects directory, it will be the value of the enviroment variable PLATFORMIO_SETTING_PROJECTS_DIR."
+        },
         "platformio-ide.reopenSerialMonitorDelay": {
           "type": "integer",
           "default": 0,
@@ -792,6 +824,11 @@
           ],
           "default": null,
           "description": "Custom base URL of the Python Package Index (default `https://pypi.org/simple`)"
+        },
+        "platformio-ide.enableTelemetry": {
+          "type": "boolean",
+          "default": true,
+          "description": "Share minimal diagnostics and usage information to help us make PlatformIO better, more information: https://docs.platformio.org/en/latest/core/userguide/cmd_settings.html#setting-enable-telemetry."
         },
         "platformio-ide.toolbar": {
           "description": "PlatformIO Toolbar",

--- a/src/main.js
+++ b/src/main.js
@@ -149,6 +149,24 @@ class PlatformIOVSCodeExtension {
     if (this.getConfiguration('customPyPiIndexUrl')) {
       extraVars['PIP_INDEX_URL'] = this.getConfiguration('customPyPiIndexUrl');
     }
+
+    // configure telemetry
+    extraVars['PLATFORMIO_SETTING_ENABLE_TELEMETRY'] = this.getConfiguration('enableTelemetry') ? 'yes' : 'no';
+
+    // configure custom paths
+    if (this.getConfiguration('platformsPATH')) {
+      extraVars['PLATFORMIO_PLATFORMS_DIR'] = this.getConfiguration('platformsPATH');
+    }
+    if (this.getConfiguration('packagesPATH')) {
+      extraVars['PLATFORMIO_PACKAGES_DIR'] = this.getConfiguration('packagesPATH');
+    }
+    if (this.getConfiguration('cachePATH')) {
+      extraVars['PLATFORMIO_CACHE_DIR'] = this.getConfiguration('cachePATH');
+    }
+    if (this.getConfiguration('projectsDirectoryPATH')) {
+      extraVars['PLATFORMIO_SETTING_PROJECTS_DIR'] = this.getConfiguration('projectsDirectoryPATH');
+    }
+
     pioNodeHelpers.proc.patchOSEnviron({
       caller: 'vscode',
       extraPath: this.getConfiguration('customPATH'),


### PR DESCRIPTION
This PR adds the capacity to use custom paths for the platforms, packages, cache and projects directories by adding a setting for each of them and a setting to enable or disable telemetry which should solve issue #898.

It works by assigning the configuration value of the environment variables:
| Configuration         | Environment variable                | Default value |
|-----------------------|-------------------------------------|---------------|
| platformsPATH         | PLATFORMIO_PLATFORMS_DIR            | null          |
| packagesPATH          | PLATFORMIO_PACKAGES_DIR             | null          |
| cachePATH             | PLATFORMIO_CACHE_DIR                | null          |
| projectsDirectoryPATH | PLATFORMIO_SETTING_PROJECTS_DIR     | null          |
| enableTelemetry       | PLATFORMIO_SETTING_ENABLE_TELEMETRY | true          |

In the case of the directories if the configuration has some value it will be assigned to the environment variable but if the configuration is null it won't create the environment variable and platformio will use the default directories.

This ability to use custom paths allows the user use a custom platformio installation like installing plaformio in a USB drive and carry all the platforms and toolchains on the go.

Currently there is some obligatory use of the `%USER%/.platformio` directory for the `appstate.json`, `homestate.json` files and `.cache/tmp` directory but i was able to work from a USB drive without any problem.