### PR TITLE
fix: problemMatcher assumes relative paths #4281

### DIFF
--- a/package.json
+++ b/package.json
@@ -683,7 +683,7 @@
         "name": "platformio",
         "owner": "cpp",
         "fileLocation": [
-          "relative",
+          "autoDetect",
           "${workspaceFolder}"
         ],
         "pattern": {


### PR DESCRIPTION

When you compile code in VSCode with platform IO, the first tab at the bottom ("problems") Does not correctly parse the filename and line number, changing to let the problem matcher try to guess is the paths are relative or absolute fixes this. Tested on linux and macos.

