### PR TITLE
Update theme detection to use activeColorTheme API

### DIFF
--- a/src/home.js
+++ b/src/home.js
@@ -100,8 +100,9 @@ export default class PIOHome {
   }
 
   getTheme() {
-    const workbench = vscode.workspace.getConfiguration('workbench') || {};
-    return (workbench.colorTheme || '').toLowerCase().includes('light')
+    const themeKind = vscode.window.activeColorTheme.kind;
+    return themeKind === vscode.ColorThemeKind.Light ||
+      themeKind === vscode.ColorThemeKind.HighContrastLight
       ? 'light'
       : 'dark';
   }


### PR DESCRIPTION
Replaced the use of `workbench.colorTheme` with the newer `window.activeColorTheme.kind` API.

This change improves compatibility with VSCode's "Window: Auto Detect Color Scheme" setting.  
When that setting is enabled, VSCode does not update `workbench.colorTheme`, but instead uses `preferredDarkColorTheme` or `preferredLightColorTheme` internally.  
As a result, relying on `colorTheme` alone may no longer reflect the actual active theme.

The new API correctly reflects the effective color theme at runtime, ensuring PlatformIO Home applies the appropriate light/dark mode on load.

**Before**
<img width="516" alt="Before" src="https://github.com/user-attachments/assets/1a093de6-9f0c-43fa-978e-fcfa0659cfa7" />

**After**
<img width="516" alt="After" src="https://github.com/user-attachments/assets/216c36f7-0547-40be-8c39-c2cc872ba3ac" />
