### PR TITLE
Fix compatibility with editors where MS Cpptools is not supported

### DIFF
--- a/package.json
+++ b/package.json
@@ -904,7 +904,7 @@
     "webpack": "~5.97.1",
     "webpack-cli": "~6.0.1"
   },
-  "extensionDependencies": [
+  "extensionPack": [
     "ms-vscode.cpptools"
   ]
 }


### PR DESCRIPTION
Listing `ms-vscode.cpptools` as hard requirement prevents this extension from loading in alternative editors where this extension is not available.

This PR moves the dependency to the "extensionPack" section, which will install cpptools if it is available, but failing to have cpptools will not prevent Platformio from activating.

This should fix #4284.