### PR TITLE
feat: decouple intellisense extension dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -890,7 +890,7 @@
   },
   "dependencies": {
     "fs-plus": "~3.1.1",
-    "platformio-node-helpers": "~11.3.0",
+    "platformio-node-helpers": "file:../platformio-node-helpers/platformio-node-helpers-11.3.0.tgz",
     "platformio-vscode-debug": "~1.4.1"
   },
   "devDependencies": {
@@ -903,8 +903,5 @@
     "prettier": "~3.4.2",
     "webpack": "~5.97.1",
     "webpack-cli": "~6.0.1"
-  },
-  "extensionDependencies": [
-    "ms-vscode.cpptools"
-  ]
+  }
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,8 +11,10 @@ export const IS_OSX = process.platform == 'darwin';
 export const IS_LINUX = !IS_WINDOWS && !IS_OSX;
 export const PIO_CORE_VERSION_SPEC = '>=6.1.6';
 export const STATUS_BAR_PRIORITY_START = 10;
+export const CPPTOOLS_EXTENSION_ID = 'ms-vscode.cpptools';
+export const CLANGD_EXTENSION_ID = 'llvm-vs-code-extensions.vscode-clangd';
+
 export const CONFLICTED_EXTENSION_IDS = [
-  'llvm-vs-code-extensions.vscode-clangd',
   'vsciot-vscode.vscode-arduino',
   'vscode-openapi',
 ];

--- a/src/main.js
+++ b/src/main.js
@@ -101,6 +101,7 @@ class PlatformIOVSCodeExtension {
 
     misc.maybeRateExtension();
     misc.warnAboutConflictedExtensions();
+    misc.warnMissingIntelliSenseEngine();
     this.subscriptions.push(
       vscode.window.onDidChangeActiveTextEditor((editor) =>
         misc.warnAboutInoFile(editor),
@@ -115,10 +116,7 @@ class PlatformIOVSCodeExtension {
   loadEnterpriseSettings() {
     const myId = this.context.extension.id;
     const ext = vscode.extensions.all.find(
-      (item) =>
-        item.id.startsWith('platformio.') &&
-        item.id !== myId &&
-        item.isActive,
+      (item) => item.id.startsWith('platformio.') && item.id !== myId && item.isActive,
     );
     return ext && ext.exports ? ext.exports.settings : undefined;
   }

--- a/src/main.js
+++ b/src/main.js
@@ -35,6 +35,7 @@ class PlatformIOVSCodeExtension {
 
   async activate(context) {
     this.context = context;
+    utils.setExtensionContext(context);
     this.pioHome = new PIOHome();
     this.pioTerm = new PIOTerminal();
     this.subscriptions.push(this.pioHome, this.pioTerm, new PIOReleaseNotes());
@@ -112,10 +113,11 @@ class PlatformIOVSCodeExtension {
   }
 
   loadEnterpriseSettings() {
+    const myId = this.context.extension.id;
     const ext = vscode.extensions.all.find(
       (item) =>
         item.id.startsWith('platformio.') &&
-        item.id !== 'platformio.platformio-ide' &&
+        item.id !== myId &&
         item.isActive,
     );
     return ext && ext.exports ? ext.exports.settings : undefined;

--- a/src/misc.js
+++ b/src/misc.js
@@ -143,6 +143,7 @@ export async function warnMissingIntelliSenseEngine() {
   const selectedItem = await vscode.window.showWarningMessage(
     'PlatformIO recommends installing a C/C++ Language Server (like Microsoft C/C++ or Clangd) for full IntelliSense.',
     { title: 'Install Microsoft C/C++', isCloseAffordance: false },
+    { title: 'Install Clangd', isCloseAffordance: false },
     { title: 'Do not show again', isCloseAffordance: false },
     { title: 'Remind later', isCloseAffordance: true },
   );
@@ -152,6 +153,12 @@ export async function warnMissingIntelliSenseEngine() {
       vscode.commands.executeCommand(
         'workbench.extensions.installExtension',
         CPPTOOLS_EXTENSION_ID,
+      );
+      break;
+    case 'Install Clangd':
+      vscode.commands.executeCommand(
+        'workbench.extensions.installExtension',
+        CLANGD_EXTENSION_ID,
       );
       break;
     case 'Do not show again':

--- a/src/misc.js
+++ b/src/misc.js
@@ -6,7 +6,11 @@
  * the root directory of this source tree.
  */
 
-import { CONFLICTED_EXTENSION_IDS } from './constants';
+import {
+  CLANGD_EXTENSION_ID,
+  CONFLICTED_EXTENSION_IDS,
+  CPPTOOLS_EXTENSION_ID,
+} from './constants';
 import { extension } from './main';
 import vscode from 'vscode';
 
@@ -115,6 +119,39 @@ export async function warnAboutInoFile(editor) {
       vscode.commands.executeCommand(
         'vscode.open',
         vscode.Uri.parse('https://bit.ly/convert-ino-to-cpp'),
+      );
+      break;
+    case 'Do not show again':
+      extension.context.globalState.update(stateKey, 1);
+      break;
+  }
+}
+
+export async function warnMissingIntelliSenseEngine() {
+  const hasCppTools = vscode.extensions.getExtension(CPPTOOLS_EXTENSION_ID);
+  const hasClangd = vscode.extensions.getExtension(CLANGD_EXTENSION_ID);
+
+  if (hasCppTools || hasClangd) {
+    return;
+  }
+
+  const stateKey = 'intellisense-warn-disabled';
+  if (extension.context.globalState.get(stateKey)) {
+    return;
+  }
+
+  const selectedItem = await vscode.window.showWarningMessage(
+    'PlatformIO recommends installing a C/C++ Language Server (like Microsoft C/C++ or Clangd) for full IntelliSense.',
+    { title: 'Install Microsoft C/C++', isCloseAffordance: false },
+    { title: 'Do not show again', isCloseAffordance: false },
+    { title: 'Remind later', isCloseAffordance: true },
+  );
+
+  switch (selectedItem ? selectedItem.title : undefined) {
+    case 'Install Microsoft C/C++':
+      vscode.commands.executeCommand(
+        'workbench.extensions.installExtension',
+        CPPTOOLS_EXTENSION_ID,
       );
       break;
     case 'Do not show again':

--- a/src/utils.js
+++ b/src/utils.js
@@ -61,7 +61,9 @@ export function setExtensionContext(context) {
 
 export function getIDEManifest() {
   if (!_extensionContext) {
-    console.warn("Attempting to get IDE manifest before extension context was injected.");
+    console.warn(
+      'Attempting to get IDE manifest before extension context was injected.',
+    );
     return { version: '0.0.0' }; // safe fallback
   }
   return _extensionContext.extension.packageJSON;

--- a/src/utils.js
+++ b/src/utils.js
@@ -53,8 +53,18 @@ export async function notifyError(title, err) {
   console.error(err);
 }
 
+let _extensionContext = null;
+
+export function setExtensionContext(context) {
+  _extensionContext = context;
+}
+
 export function getIDEManifest() {
-  return vscode.extensions.getExtension('platformio.platformio-ide').packageJSON;
+  if (!_extensionContext) {
+    console.warn("Attempting to get IDE manifest before extension context was injected.");
+    return { version: '0.0.0' }; // safe fallback
+  }
+  return _extensionContext.extension.packageJSON;
 }
 
 export function getIDEVersion() {


### PR DESCRIPTION
**TL:DR**: Decouples hardcoded extension ID lookups and implements a soft-dependency facade for IntelliSense engines to allow activation in open-source editors, and other platforms like Google Antigravity, that do not use the Microsoft restricted marketplace (e.g. instead use Open VSX).

## Rationale
Historically, PlatformIO's VS Code extension relied on hardcoded identifier lookups (`platformio.platformio-ide`) and aggressive conflict management, which assumes a very standard Microsoft VS Code environment. 
As developers increasingly migrate toward authorized open-source IDE variants and AI-agentic editors (such as Google's Antigravity IDE, Cursor, and VSCodium), these hardcoded assumptions either crash the extension or prevent fundamental features (like IntelliSense) from hooking into the workspace correctly. 
This PR modernizes the extension’s architecture by decoupling it from strict environmental assumptions, converting rigid extension ID checks into a soft-dependency facade. This allows PlatformIO to organically activate and fully function inside non-standard VS Code forks without negatively impacting the native Microsoft VS Code experience.
## Changes Included
*   **Dynamic Extension Context Checking (`src/main.js` & `src/utils.js`)**: 
    Removed hardcoded references to `platformio.platformio-ide`. IDE manifest fetches now safely failover if called prior to the context injection step, preventing uncaught initialization crashes in alternative editors.
*   **Soft-Dependency Facade for Language Servers (`src/constants.js`)**:
    Registered `ms-vscode.cpptools` and `llvm-vs-code-extensions.vscode-clangd` dynamically. 
*   **Decoupled Extension Conflicts (`src/constants.js` & `src/misc.js`)**:
    Removed `vscode-clangd` from the `CONFLICTED_EXTENSION_IDS` array so it is no longer forcibly uninstalled/disabled. 
*   **Graceful User Warnings (`src/misc.js`)**:
    Implemented the `warnMissingIntelliSenseEngine()` routine to detect whether the user lacks an installed C/C++ engine, and prompts an optional, dismissible warning to install one, restoring choice to the user ecosystem.
    
  ## Related Changes
 [FR: Official Support for Google Antigravity IDE #4417](https://github.com/platformio/platformio-vscode-ide/issues/4417)
[platformio-node-helpers #24](https://github.com/platformio/platformio-node-helpers/pull/24)
 fix: enforce strict python baseline < 3.13