### PR TITLE
Support VS Code forks without browser-based setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -903,8 +903,5 @@
     "prettier": "~3.4.2",
     "webpack": "~5.97.1",
     "webpack-cli": "~6.0.1"
-  },
-  "extensionDependencies": [
-    "ms-vscode.cpptools"
-  ]
+  }
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,8 +11,10 @@ export const IS_OSX = process.platform == 'darwin';
 export const IS_LINUX = !IS_WINDOWS && !IS_OSX;
 export const PIO_CORE_VERSION_SPEC = '>=6.1.6';
 export const STATUS_BAR_PRIORITY_START = 10;
+export const CPPTOOLS_EXTENSION_ID = 'ms-vscode.cpptools';
+export const CLANGD_EXTENSION_ID = 'llvm-vs-code-extensions.vscode-clangd';
+
 export const CONFLICTED_EXTENSION_IDS = [
-  'llvm-vs-code-extensions.vscode-clangd',
   'vsciot-vscode.vscode-arduino',
   'vscode-openapi',
 ];

--- a/src/main.js
+++ b/src/main.js
@@ -35,6 +35,7 @@ class PlatformIOVSCodeExtension {
 
   async activate(context) {
     this.context = context;
+    utils.setExtensionContext(context);
     this.pioHome = new PIOHome();
     this.pioTerm = new PIOTerminal();
     this.subscriptions.push(this.pioHome, this.pioTerm, new PIOReleaseNotes());
@@ -100,6 +101,7 @@ class PlatformIOVSCodeExtension {
 
     misc.maybeRateExtension();
     misc.warnAboutConflictedExtensions();
+    misc.warnMissingIntelliSenseEngine();
     this.subscriptions.push(
       vscode.window.onDidChangeActiveTextEditor((editor) =>
         misc.warnAboutInoFile(editor),
@@ -112,11 +114,9 @@ class PlatformIOVSCodeExtension {
   }
 
   loadEnterpriseSettings() {
+    const myId = this.context.extension.id;
     const ext = vscode.extensions.all.find(
-      (item) =>
-        item.id.startsWith('platformio.') &&
-        item.id !== 'platformio.platformio-ide' &&
-        item.isActive,
+      (item) => item.id.startsWith('platformio.') && item.id !== myId && item.isActive,
     );
     return ext && ext.exports ? ext.exports.settings : undefined;
   }

--- a/src/misc.js
+++ b/src/misc.js
@@ -6,7 +6,11 @@
  * the root directory of this source tree.
  */
 
-import { CONFLICTED_EXTENSION_IDS } from './constants';
+import {
+  CLANGD_EXTENSION_ID,
+  CONFLICTED_EXTENSION_IDS,
+  CPPTOOLS_EXTENSION_ID,
+} from './constants';
 import { extension } from './main';
 import vscode from 'vscode';
 
@@ -115,6 +119,46 @@ export async function warnAboutInoFile(editor) {
       vscode.commands.executeCommand(
         'vscode.open',
         vscode.Uri.parse('https://bit.ly/convert-ino-to-cpp'),
+      );
+      break;
+    case 'Do not show again':
+      extension.context.globalState.update(stateKey, 1);
+      break;
+  }
+}
+
+export async function warnMissingIntelliSenseEngine() {
+  const hasCppTools = vscode.extensions.getExtension(CPPTOOLS_EXTENSION_ID);
+  const hasClangd = vscode.extensions.getExtension(CLANGD_EXTENSION_ID);
+
+  if (hasCppTools || hasClangd) {
+    return;
+  }
+
+  const stateKey = 'intellisense-warn-disabled';
+  if (extension.context.globalState.get(stateKey)) {
+    return;
+  }
+
+  const selectedItem = await vscode.window.showWarningMessage(
+    'PlatformIO recommends installing a C/C++ Language Server (like Microsoft C/C++ or Clangd) for full IntelliSense.',
+    { title: 'Install Microsoft C/C++', isCloseAffordance: false },
+    { title: 'Install Clangd', isCloseAffordance: false },
+    { title: 'Do not show again', isCloseAffordance: false },
+    { title: 'Remind later', isCloseAffordance: true },
+  );
+
+  switch (selectedItem ? selectedItem.title : undefined) {
+    case 'Install Microsoft C/C++':
+      vscode.commands.executeCommand(
+        'workbench.extensions.installExtension',
+        CPPTOOLS_EXTENSION_ID,
+      );
+      break;
+    case 'Install Clangd':
+      vscode.commands.executeCommand(
+        'workbench.extensions.installExtension',
+        CLANGD_EXTENSION_ID,
       );
       break;
     case 'Do not show again':

--- a/src/utils.js
+++ b/src/utils.js
@@ -53,8 +53,20 @@ export async function notifyError(title, err) {
   console.error(err);
 }
 
+let _extensionContext = null;
+
+export function setExtensionContext(context) {
+  _extensionContext = context;
+}
+
 export function getIDEManifest() {
-  return vscode.extensions.getExtension('platformio.platformio-ide').packageJSON;
+  if (!_extensionContext) {
+    console.warn(
+      'Attempting to get IDE manifest before extension context was injected.',
+    );
+    return { version: '0.0.0' }; // safe fallback
+  }
+  return _extensionContext.extension.packageJSON;
 }
 
 export function getIDEVersion() {


### PR DESCRIPTION
This change makes PlatformIO IDE work more reliably in VS Code forks such as Antigravity, where hardcoded extension assumptions and marketplace coupling can block activation or IntelliSense setup.

The fix removes the hardcoded self-extension lookup and resolves the extension ID from the active runtime context instead. That keeps manifest lookups safe during activation and avoids breaking in editors that do not use the standard Microsoft VS Code extension identity.

It also removes the forced `ms-vscode.cpptools` dependency and adds a soft IntelliSense recommendation flow that installs the C/C++ engine directly in the editor via `workbench.extensions.installExtension`. This avoids opening a browser just to complete a required setup step and makes the workflow work in forked IDEs and Open VSX-based environments.

A small compatibility tweak is also included: Clangd is no longer treated as a conflicted extension, so valid IntelliSense engines are not disabled by PlatformIO itself.